### PR TITLE
Register NL parameters in JuMP model

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -68,6 +68,7 @@ function build(m::Model)
 
     for p in m._parameters
         jmp_p = @eval(JuMP.@NLparameter($jm, $(p.name) == $(p.value)))
+        jm[p.name] = jmp_p
         m._jump_nlparameters[p.name] = jmp_p
     end
 


### PR DESCRIPTION
This is a workaround for now because JuMP doesn't register
these automatically.