### PR TITLE
Set benchmark for Y

### DIFF
--- a/examples/example4.jl
+++ b/examples/example4.jl
@@ -20,7 +20,7 @@ X = add!(m, Sector(:X, indices=(sectors,)))
 P = add!(m, Commodity(:P, indices=(goods,)))
 PF = add!(m, Commodity(:PF, indices=(factors,)))
 
-Y = add!(m, Consumer(:Y)) # Do we need a benchmark here?
+Y = add!(m, Consumer(:Y, benchmark=sum(fd0)))
 
 for j in sectors
     @production(m, X[j], 1, [Output(P[i], make0[i,j]) for i in goods], [[Input(P[i], use0[i,j]) for i in goods]; [Input(PF[f], fd0[f,j]) for f in factors]])


### PR DESCRIPTION
With this, model 4 solves! The benchmark is the same that is set in the GAMS code.

One question is whether the benchmark _always_ has to be the sum of the endowments, in which case we could presumably do away with the benchmark option entirely and just always set the correct starting value. But for now, this will do.