### PR TITLE
Split Params into Scal/Indexed

### DIFF
--- a/src/build/build_startvalues_bounds.jl
+++ b/src/build/build_startvalues_bounds.jl
@@ -96,6 +96,12 @@ function set_all_parameters(m)
     jm = m._jump_model
 
     for p in m._parameters
-        JuMP.set_value(jm[p.name], p.value)
+        if p isa ScalarParameter
+            JuMP.set_value(jm[p.name], p.value)
+        else
+            for pp in p.indices
+                JuMP.set_value(jm[pp.name], pp.value)
+            end
+        end
     end
 end

--- a/src/build/build_variables.jl
+++ b/src/build/build_variables.jl
@@ -6,6 +6,15 @@ function add_variable!(jm::JuMP.Model, name::Symbol, lower_bound::Union{Float64,
     end
 end
 
+function add_parameter_to_jump!(jm, parameter::ScalarParameter)
+    jmp_p = @eval(JuMP.@NLparameter($jm, $(parameter.name) == $(parameter.value)))
+    jm[parameter.name] = jmp_p
+end
+
+function add_parameter_to_jump!(jn, parameter::IndexedParameter)
+    jm[parameter.name] = @eval(JuMP.@NLparameter($jm, [$( ( :($(gensym())=$i) for i in parameter.indices)... )], base_name=string($(QuoteNode(parameter.name)))))
+end
+
 function add_sector_to_jump!(jm, sector::ScalarSector)
     add_variable!(jm, sector.name, 0.)
 end
@@ -34,8 +43,9 @@ function build_variables!(m, jm)
     # Add all parameters
 
     for p in m._parameters
-        jmp_p = @eval(JuMP.@NLparameter($jm, $(p.name) == $(p.value)))
-        jm[p.name] = jmp_p
+        add_parameter_to_jump!(jm, p)
+        # jmp_p = @eval(JuMP.@NLparameter($jm, $(p.name) == $(p.value)))
+        # jm[p.name] = jmp_p
     end
 
     # Add all required variables

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -7,7 +7,7 @@ function _add_kw_args(call, kw_args)
 end
 
 macro parameter(model, name, value, kwargs...)
-    constr_call = :(Parameter($(QuoteNode(name)), $(esc(value))))
+    constr_call = :(Parameter($(QuoteNode(name)), value=($(esc(value)))))
 
     _add_kw_args(constr_call, kwargs)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,10 +7,10 @@ using MPSGE.JuMP.Containers
     @testset "TWOBYTWO (functional version)" begin
         m = Model()
        
-        inputcoeff = add!(m, Parameter(:inputcoeff, 2.))
-        endow = add!(m, Parameter(:endow, 2.))
-        elascoeff = add!(m, Parameter(:elascoeff, 2.))
-        outputmult = add!(m, Parameter(:outputmult, 2.))
+        inputcoeff = add!(m, Parameter(:inputcoeff, value=2.))
+        endow = add!(m, Parameter(:endow, value=2.))
+        elascoeff = add!(m, Parameter(:elascoeff, value=2.))
+        outputmult = add!(m, Parameter(:outputmult, value=2.))
 
         
         X = add!(m, Sector(:X))


### PR DESCRIPTION
This passes our tests as is. We don't have a test of indexed parameters yet, so...might break.
At this point, I added "value=" to the API add! and to the macro to make it work. I'm sure there's a better way to do that.