### PR TITLE
Change In/Out Tax&Price to (optional) Keyword args

### DIFF
--- a/examples/example3.jl
+++ b/examples/example3.jl
@@ -22,7 +22,7 @@ PF = add!(m, Commodity(:PF, indices=(factors,)))
 RA = add!(m, Consumer(:RA, benchmark = 150.))
 
 for i in goods
-    @production(m, Y[i], 0, 1, [Output(PC[i], supply[i], [Tax(:(1 * $(outtax[i])), RA)])], [Input(PF[:l], factor[i,:l], [Tax(:(1 * $(intax[i])), RA)]), Input(PF[:k], factor[i,:k])])
+    @production(m, Y[i], 0, 1, [Output(PC[i], supply[i], taxes=[Tax(:(1 * $(outtax[i])), RA)])], [Input(PF[:l], factor[i,:l], taxes=[Tax(:(1 * $(intax[i])), RA)]), Input(PF[:k], factor[i,:k])])
 end
 # @production(m, [i in goods], Y[i], 1, PC[i], supply[i],  [Input(PF[f], factor[i,f]) for f in factors])
 

--- a/examples/example5.jl
+++ b/examples/example5.jl
@@ -89,11 +89,11 @@ TAU_TL = add!(m,Aux(:TAU_TL, benchmark=0.)) # Labor tax replacement
 UR = add!(m,Aux(:UR, benchmark=0.)) # Unemployment rate
 
 add!(m, Production(Y, :($etadx*1.0), :($esubkl*1.0),
- [Output(PD, d0), Output(PX, x0, [Tax(tx,GOVT)], px0)],
- [Input(RK, kd0, [Tax(tk, GOVT)], rr0), Input(PL, ly0, [Tax(:($tl+$TAU_TL),GOVT)], pl0)] ))
+ [Output(PD, d0), Output(PX, x0, taxes=[Tax(tx,GOVT)], price=px0)],
+ [Input(RK, kd0, taxes=[Tax(tk, GOVT)], price=rr0), Input(PL, ly0, taxes=[Tax(:($tl+$TAU_TL),GOVT)], price=pl0)] ))
 # add!(m, Production(Y, :($etadx*1.0), :($esubkl*1.0), [Output(PD, d0), Output(PX, x0, [Tax(tx,GOVT)], px0)], [Input(RK, kd0, [Tax(tk, GOVT)], rr0), Input(PL, ly0, [Tax(tl,GOVT), Tax(:($TAU_TL*1),GOVT)], pl0)] ))
 
-add!(m, Production(A, 0., :($sigmadm*1.0), [Output(PA, a0, [Tax(ta,GOVT)])], [Input(PD, d0), Input(PM, m0, [Tax(:($TM*1.),GOVT)], pm0)] ))
+add!(m, Production(A, 0., :($sigmadm*1.0), [Output(PA, a0, taxes=[Tax(ta,GOVT)])], [Input(PD, d0), Input(PM, m0, taxes=[Tax(:($TM*1.),GOVT)], price=pm0)] ))
 add!(m, Production(M, 0., 1.0, [Output(PM, m0)], [Input(PFX, :($pwm*$m0))] ))
 add!(m, Production(X, 0., 1.0, [Output(PFX, :($pwx*$x0))], [Input(PX, x0)] ))
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -204,7 +204,7 @@ mutable struct Input
     price::Union{Float64,Expr}
     production_function::Any
 
-    function Input(commodity, quantity::Union{Float64,Expr}, taxes::Vector{Tax}=Tax[], price::Union{Float64,Expr}=1.)
+    function Input(commodity, quantity::Union{Float64,Expr}; taxes::Vector{Tax}=Tax[], price::Union{Float64,Expr}=1.)
         return new(commodity, quantity, taxes, price, nothing)
     end
 end
@@ -216,7 +216,7 @@ mutable struct Output
     price::Union{Float64,Expr}
     production_function::Any
 
-    function Output(commodity::CommodityRef, quantity::Union{Float64,Expr}, taxes::Vector{Tax}=Tax[], price::Union{Float64,Expr}=1.)
+    function Output(commodity::CommodityRef, quantity::Union{Float64,Expr}; taxes::Vector{Tax}=Tax[], price::Union{Float64,Expr}=1.)
         return new(commodity, quantity, taxes, price, nothing)
     end
 end
@@ -490,12 +490,12 @@ end
 
 # Outer constructors
 
-function Input(commodity, quantity::Number, taxes::Vector{Tax}=Tax[], price::Union{Float64,Expr}=1.)
-    return Input(commodity, convert(Float64, quantity), taxes, price)
+function Input(commodity, quantity::Number; taxes::Vector{Tax}=Tax[], price::Union{Float64,Expr}=1.)
+    return Input(commodity, convert(Float64, quantity), taxes=taxes, price=price)
 end
 
-function Output(commodity::CommodityRef, quantity::Number, taxes::Vector{Tax}=Tax[], price::Union{Float64,Expr}=1.)
-    return Output(commodity, convert(Float64, quantity), taxes, price)
+function Output(commodity::CommodityRef, quantity::Number; taxes::Vector{Tax}=Tax[], price::Union{Float64,Expr}=1.)
+    return Output(commodity, convert(Float64, quantity), taxes=taxes, price=price)
 end
 
 function Production(sector::SectorRef, tr_elasticity::Union{Number,Expr}, elasticity::Union{Number,Expr}, outputs::Vector{Output}, inputs::Vector{Input})
@@ -623,7 +623,7 @@ function add!(m::Model, p::Production)
             commodity_ref = add!(m, Commodity(commodity_name))
             add!(m, Production(sector_ref, 0, v.commodity.elasticity, [Output(commodity_ref, v.commodity.benchmark)], v.commodity.inputs))
 
-            new_input = Input(commodity_ref, v.quantity, v.taxes, v.price)
+            new_input = Input(commodity_ref, v.quantity, taxes=v.taxes, price=v.price)
             new_input.production_function = v.production_function
             p.inputs[i] = new_input
         end

--- a/test/test_123.jl
+++ b/test/test_123.jl
@@ -70,11 +70,11 @@ TAU_TL = add!(m,Aux(:TAU_TL, benchmark=0.)) # Labor tax replacement
 UR = add!(m,Aux(:UR, benchmark=0.)) # Unemployment rate
 
 add!(m, Production(Y, :($etadx*1.0), :($esubkl*1.0),
- [Output(PD, d0), Output(PX, x0, [Tax(tx,GOVT)], px0)],
- [Input(RK, kd0, [Tax(tk, GOVT)], rr0), Input(PL, ly0, [Tax(:($tl+$TAU_TL),GOVT)], pl0)] ))
+ [Output(PD, d0), Output(PX, x0, taxes=[Tax(tx,GOVT)], price=px0)],
+ [Input(RK, kd0, taxes=[Tax(tk, GOVT)], price=rr0), Input(PL, ly0, taxes=[Tax(:($tl+$TAU_TL),GOVT)], price=pl0)] ))
 # add!(m, Production(Y, :($etadx*1.0), :($esubkl*1.0), [Output(PD, d0), Output(PX, x0, [Tax(tx,GOVT)], px0)], [Input(RK, kd0, [Tax(tk, GOVT)], rr0), Input(PL, ly0, [Tax(tl,GOVT), Tax(:($TAU_TL*1),GOVT)], pl0)] ))
 
-add!(m, Production(A, 0., :($sigmadm*1.0), [Output(PA, a0, [Tax(ta,GOVT)])], [Input(PD, d0), Input(PM, m0, [Tax(:($TM*1.),GOVT)], pm0)] ))
+add!(m, Production(A, 0., :($sigmadm*1.0), [Output(PA, a0, taxes=[Tax(ta,GOVT)])], [Input(PD, d0), Input(PM, m0, taxes=[Tax(:($TM*1.),GOVT)], price=pm0)] ))
 add!(m, Production(M, 0., 1.0, [Output(PM, m0)], [Input(PFX, :($pwm*$m0))] ))
 add!(m, Production(X, 0., 1.0, [Output(PFX, :($pwx*$x0))], [Input(PX, x0)] ))
 
@@ -377,12 +377,12 @@ TAU_TL = add!(m,Aux(:TAU_TL, benchmark=0.)) # Labor tax replacement
 UR = add!(m,Aux(:UR, benchmark=0.)) # Unemployment rate
 
 add!(m, Production(Y, :($etadx*1.0), :($esubkl*1.0),
- [Output(PD, d0), Output(PX, x0, [Tax(tx,GOVT)], px0)],
- [Input(RK, kd0, [Tax(tk, GOVT)], rr0), Input(PL, ly0, [Tax(:($tl+$TAU_TL),GOVT)], pl0)] ))
+ [Output(PD, d0), Output(PX, x0, taxes=[Tax(tx,GOVT)], price=px0)],
+ [Input(RK, kd0, taxes=[Tax(tk, GOVT)], price=rr0), Input(PL, ly0, taxes=[Tax(:($tl+$TAU_TL),GOVT)], price=pl0)] ))
 
 add!(m, Production(X, 0., 1.0, [Output(PFX, :($pwx*$x0))], [Input(PX, x0)] ))
-add!(m, Production(A, 0., :($sigmadm*1.0), [Output(PA, a0, [Tax(ta,GOVT)])], [Input(PD, (d0-cd0)), Input(PM, (m0-cm0))]))
-add!(m, Production(M, 0., 1.0, [Output(PM, m0)], [Input(PFX, :($pwm*$m0/$pm0), [Tax(:($TM*1.), GOVT)])]))
+add!(m, Production(A, 0., :($sigmadm*1.0), [Output(PA, a0, taxes=[Tax(ta,GOVT)])], [Input(PD, (d0-cd0)), Input(PM, (m0-cm0))]))
+add!(m, Production(M, 0., 1.0, [Output(PM, m0)], [Input(PFX, :($pwm*$m0/$pm0), taxes=[Tax(:($TM*1.), GOVT)])]))
 
 add!(m, DemandFunction(GOVT, 0.,
  [Demand(PA , 35.583)],

--- a/test/test_twobytwo_Price.jl
+++ b/test/test_twobytwo_Price.jl
@@ -28,7 +28,7 @@ PK = add!(m, Commodity(:PK))
 
 RA = add!(m, Consumer(:RA, benchmark=164.))
 
-add!(m, Production(X, 0, :(1.0 * $esub_x), [Output(PX, 110, [Tax(:($otax*1.),RA)])], [Input(PL, 50, [Tax(:($itax*1.),RA)], 1.2), Input(PK, 50)]))
+add!(m, Production(X, 0, :(1.0 * $esub_x), [Output(PX, 110, taxes=[Tax(:($otax*1.),RA)])], [Input(PL, 50, taxes=[Tax(:($itax*1.),RA)], price=1.2), Input(PK, 50)]))
 add!(m, Production(Y, 0, :(1.0 * $esub_y), [Output(PY, 54)], [Input(PL, 24,), Input(PK, 30)]))
 add!(m, Production(U, 0, :(1.0 * $esub_u), [Output(PU, 164.)], [Input(PX, 110), Input(PY, 54)]))
 
@@ -217,7 +217,7 @@ PK = add!(m, Commodity(:PK))
 
 RA = add!(m, Consumer(:RA, benchmark=154.))
 
-add!(m, Production(X, 0, :(1.0 * $esub_x), [Output(PX, 100, [Tax(:($otax*1.),RA)], 1.2)], [Input(PL, 30, [Tax(:($itax*1.),RA)]), Input(PK, 50)]))
+add!(m, Production(X, 0, :(1.0 * $esub_x), [Output(PX, 100, taxes=[Tax(:($otax*1.),RA)], price=1.2)], [Input(PL, 30, taxes=[Tax(:($itax*1.),RA)]), Input(PK, 50)]))
 add!(m, Production(Y, 0, :(1.0 * $esub_y), [Output(PY, 54)], [Input(PL, 24,), Input(PK, 30)]))
 add!(m, Production(U, 0, :(1.0 * $esub_u), [Output(PU, 154.)], [Input(PX, 100), Input(PY, 54)]))
 
@@ -405,11 +405,11 @@ PK = add!(m, Commodity(:PK))
 
 RA = add!(m, Consumer(:RA, benchmark=134.))
 
-add!(m, Production(X, 0, :(1.0 * $esub_x), [Output(PX, 80, [Tax(:($otax*1.),RA)])], [Input(PL, 30, [Tax(:($itax*1.),RA)]), Input(PK, 50)]))
+add!(m, Production(X, 0, :(1.0 * $esub_x), [Output(PX, 80, taxes=[Tax(:($otax*1.),RA)])], [Input(PL, 30, taxes=[Tax(:($itax*1.),RA)]), Input(PK, 50)]))
 # add!(m, Production(Y, 0, :(1.0 * $esub_y), [Output(PY, 54)], [Input(PL, 20), Input(PK, 30)]))
 # add!(m, Production(Y, 0, :(1.0 * $esub_y), [Output(PY, 54)],                         [Input(PL, 20, [Tax(:($itax*1.),RA)], 1.2), Input(PK, 30)]))
 add!(m, Production(Y, 0, :(1.0 * $esub_y), [Output(PY, 54)], [Input(PL, 24,), Input(PK, 30)]))
-add!(m, Production(U, 0, :(1.0 * $esub_u), [Output(PU, 124., [Tax(0.,RA)], 1.)], [Input(PX, 80), Input(PY, 44)]))
+add!(m, Production(U, 0, :(1.0 * $esub_u), [Output(PU, 124., price=1.)], [Input(PX, 80), Input(PY, 44)]))
 
 add!(m, DemandFunction(RA, :($esub_ra*1.), [Demand(PU,124., :($pr_Ud*1.)), Demand(PY,10, 1.0)], [Endowment(PL, :(54. *$endow)), Endowment(PK, 80)]))
 

--- a/test/test_twobytwo_indexed.jl
+++ b/test/test_twobytwo_indexed.jl
@@ -19,7 +19,7 @@
     C = add!(m, Consumer(:C, indices=(consumers,), benchmark=150.))
 
     for i in goods
-        @production(m, Y[i], 0, 1, [Output(PC[i], supply[i], [Tax(:(1 * $(outax[i])), C[:ra])])], [Input(PF[:l], factor[i,:l], [Tax(:(1 * $(intax[i])), C[:ra])]), Input(PF[:k], factor[i,:k])])
+        @production(m, Y[i], 0, 1, [Output(PC[i], supply[i], taxes=[Tax(:(1 * $(outax[i])), C[:ra])])], [Input(PF[:l], factor[i,:l], taxes=[Tax(:(1 * $(intax[i])), C[:ra])]), Input(PF[:k], factor[i,:k])])
     end
     @production(m, U, 0, 1, [Output(PU, 150)], [Input(PC[:x], 100), Input(PC[:y], 50)])
     @demand(m, C[:ra], 1., [Demand(PU, 150)], [Endowment(PF[:l], :(70 * $(endow[:l]))), Endowment(PF[:k], :(80. * $(endow[:k])))])
@@ -208,7 +208,7 @@ end
         for i in goods
             @production(m, Y[i], 0, 1, [Output(PC[i], supply[i])], [Input(PF[:l], factor[i,:l]), Input(PF[:k], factor[i,:k])])
         end
-        add!(m, Production(U, 0., 1.0, [Output(PU, 150)], [Input(PC[i], supply[i], [Tax(0.,C[:ra])], :($(pricepci[i])*1.)) for i in goods]))
+        add!(m, Production(U, 0., 1.0, [Output(PU, 150)], [Input(PC[i], supply[i], price=:($(pricepci[i])*1.)) for i in goods]))
     
         @demand(m, C[:ra], 1., [Demand(PU, 150)], [Endowment(PF[:l], :(70 * $(endow[:l]))), Endowment(PF[:k], :(80. * $(endow[:k])))])
     
@@ -368,7 +368,7 @@ end
                      1.,
                       150.,
                       [
-                        Input(PC[i], supply[i], [Tax(0.,C[:ra])], :($(pricepci[i])*1.)) for i in goods
+                        Input(PC[i], supply[i], price=:($(pricepci[i])*1.)) for i in goods
                         ]
                         ), 150
                         )

--- a/test/test_twobytwo_wTaxes.jl
+++ b/test/test_twobytwo_wTaxes.jl
@@ -21,7 +21,7 @@ PK = add!(m, Commodity(:PK))
 
 RA = add!(m, Consumer(:RA, benchmark = 150.))
 
-@production(m, X, 0, :($esub_x*1.0), [Output(PX, 100., [Tax(:($otax*1.0), RA)])], [Input(PL, 50.), Input(PK,50.)])
+@production(m, X, 0, :($esub_x*1.0), [Output(PX, 100., taxes=[Tax(:($otax*1.0), RA)])], [Input(PL, 50.), Input(PK,50.)])
 @production(m, Y, 0, :($esub_y*1.0), [Output(PY, 50.)], [Input(PL, 20.), Input(PK,30.)])
 @production(m, U, 0, 1.0, [Output(PU, 150.)], [Input(PX, 100.), Input(PY,50.)])
 
@@ -260,8 +260,8 @@ end
     
     RA = add!(m, Consumer(:RA, indices=(consumers,), benchmark=75.))#(consumption)))
  
-    @production(m, X, 0, :($esub_x*1.0), [Output(PX, 100., [Tax(:($otaxa*1.0), RA[:a])])], [Input(PL, 50.), Input(PK,50.)])
-    @production(m, Y, 0, :($esub_y*1.0), [Output(PY, 50.,  [Tax(:($otaxb*1.0), RA[:b])])], [Input(PL, 20.), Input(PK,30.)])
+    @production(m, X, 0, :($esub_x*1.0), [Output(PX, 100., taxes=[Tax(:($otaxa*1.0), RA[:a])])], [Input(PL, 50.), Input(PK,50.)])
+    @production(m, Y, 0, :($esub_y*1.0), [Output(PY, 50.,  taxes=[Tax(:($otaxb*1.0), RA[:b])])], [Input(PL, 20.), Input(PK,30.)])
     @production(m, U, 0, 1.0, [Output(PU, 150.)], [Input(PX, 100.), Input(PY,50.)])
 
     for r in consumers
@@ -631,8 +631,8 @@ end
     
     @consumer(m, CONS, benchmark=200.0)
     
-    @production(m, A, :($t_elas_a*1.), :($sub_elas_a*1.), [Output(PX, 80, [Tax(:($otax1*1.0), CONS)]), Output(PY, 20, [Tax(:($otax2*1.0), CONS)])], [Input(PL, 40, [Tax(:($itax*1.0), CONS)]), Input(PK, 60, [Tax(:($itax*1.0), CONS)])])
-    @production(m, B, :($t_elas_b*1.), :($sub_elas_b*1.), [Output(PX, 20, [Tax(:($otax3*1.0), CONS)]), Output(PY, 80, [Tax(:($otax4*1.0), CONS)])], [Input(PL, 60), Input(PK, 40)])
+    @production(m, A, :($t_elas_a*1.), :($sub_elas_a*1.), [Output(PX, 80, taxes=[Tax(:($otax1*1.0), CONS)]), Output(PY, 20, taxes=[Tax(:($otax2*1.0), CONS)])], [Input(PL, 40, taxes=[Tax(:($itax*1.0), CONS)]), Input(PK, 60, taxes=[Tax(:($itax*1.0), CONS)])])
+    @production(m, B, :($t_elas_b*1.), :($sub_elas_b*1.), [Output(PX, 20, taxes=[Tax(:($otax3*1.0), CONS)]), Output(PY, 80, taxes=[Tax(:($otax4*1.0), CONS)])], [Input(PL, 60), Input(PK, 40)])
     @production(m, W, 0, :($sub_elas_w*1.), [Output(PW, 200.0)],[Input(PX, 100.0), Input(PY, 100.0)])
     
     @demand(m, CONS, 1., [Demand(PW, 200.)], [Endowment(PL, 100.0), Endowment(PK, 100.0)])
@@ -1241,8 +1241,8 @@ end
     CONS = add!(m, Consumer(:CONS, benchmark=200.))
     
     U = add!(m, Aux(:U, benchmark=0.2))
-    add!(m, Production(X, 0, 1.0, [Output(PX, 100, [Tax(:(1.0*$tx),CONS)])], [Input(PK, 50, [Tax(:($tkx*1.),CONS)]), Input(PL, 40)]))
-    add!(m, Production(Y, 0, 1.0, [Output(PY, 100, [Tax(:(1.0*$ty),CONS)])], [Input(PL, 60), Input(PK, 40)]))
+    add!(m, Production(X, 0, 1.0, [Output(PX, 100, taxes=[Tax(:(1.0*$tx),CONS)])], [Input(PK, 50, taxes=[Tax(:($tkx*1.),CONS)]), Input(PL, 40)]))
+    add!(m, Production(Y, 0, 1.0, [Output(PY, 100, taxes=[Tax(:(1.0*$ty),CONS)])], [Input(PL, 60), Input(PK, 40)]))
     add!(m, Production(W, 0, 1.0, [Output(PW, 200.)], [Input(PX, 100), Input(PY, 100)]))
     
     add!(m, DemandFunction(CONS, 1., [Demand(PW,200.)], [Endowment(PL, 120.), Endowment(PL, :(-80/(1-$uo)*$U)), Endowment(PK, 90)]))
@@ -1423,8 +1423,8 @@ add!(m, Production(X, 0, 1.0, [Output(PX, 120.)], [Input(PLS, 48), Input(PKS, 72
 add!(m, Production(Y, 0, 1.0, [Output(PY, 120.)], [Input(PLS, 72), Input(PKS, 48)]))
 add!(m, Production(W, 0, 0.7, [Output(PW, 340.)], [Input(Nest(:AW,1.0,240.,[Input(PX, 120), Input(PY, 120)]),240.), Input(PL,100.)]))
 
-add!(m, Production(TL, 0., 1.0, [Output(PLS, 120.)], [Input(PL, 100., [Tax(:(1.0*$txl*$TAU),CONS)])]))
-add!(m, Production(TK, 0., 1.0, [Output(PKS, 120.)], [Input(PK, 100., [Tax(:(1.0*$txk*$TAU),CONS)])]))
+add!(m, Production(TL, 0., 1.0, [Output(PLS, 120.)], [Input(PL, 100., taxes=[Tax(:(1.0*$txl*$TAU),CONS)])]))
+add!(m, Production(TK, 0., 1.0, [Output(PKS, 120.)], [Input(PK, 100., taxes=[Tax(:(1.0*$txk*$TAU),CONS)])]))
 
 add!(m, DemandFunction(CONS, 1., [Demand(PW,340.)], [Endowment(PL, 200.), Endowment(PK, 100)]))
 add!(m, AuxConstraint(TAU, :($W*$PW*340 - $PL * 200 - $PK * 100  == 40 * ($PX + $PY)/2)))
@@ -1667,7 +1667,7 @@ CONS = add!(m, Consumer(:CONS, benchmark=180.))
 SHAREX = add!(m, Aux(:SHAREX, benchmark=0.5))
 MARKUP = add!(m, Aux(:MARKUP, indices=(muindex,), benchmark=0.2))
 
-add!(m, Production(X, 0, 1.0, [Output(PX, 80., [Tax(:(1.0*$(MARKUP[:a])), CONS)])], [Input(PL, 14), Input(PK, 50)]))
+add!(m, Production(X, 0, 1.0, [Output(PX, 80., taxes=[Tax(:(1.0*$(MARKUP[:a])), CONS)])], [Input(PL, 14), Input(PK, 50)]))
 add!(m, Production(Y, 0, 1.0, [Output(PY, 100.)],                             [Input(PL, 60), Input(PK, 40)]))
 add!(m, Production(W, 0, 9.0, [Output(PW, 180.)], [Input(PX,80), Input(PY,100.)]))
 


### PR DESCRIPTION
This implements setting taxes and price in Input and Output to optional keyword arguments, particularly in order to be able to use a nonunitary price without have to include a 0 tax. All tests and examples are updated.