### PR TITLE
Don't create JuMP vars during expression build

### DIFF
--- a/src/build/build.jl
+++ b/src/build/build.jl
@@ -3,6 +3,8 @@ function build(m::Model)
     jm = Complementarity.MCPModel()
 
     build_variables!(m, jm)
+
+    add_implicitvars!(m)
     
     build_implicitconstraints!(m, jm)
 

--- a/src/build/build_auxconstraints.jl
+++ b/src/build/build_auxconstraints.jl
@@ -4,7 +4,7 @@ function build_auxconstraints!(m::Model, jm)
         ac.equation isa Expr || error("You must pass an expression as an aux constraint.")
         (ac.equation.head == :call && length(ac.equation.args) == 3 && ac.equation.args[1] == :(==)) || error("Must pass an equation with an == sign.")
 # TODO Need >=, and possibly <=
-        equation_expr = swap_our_param_with_jump_param(jm, :( $(ac.equation.args[2]) - $(ac.equation.args[3]) ))
+        equation_expr = swap_our_Ref_with_jump_var(jm, :( $(ac.equation.args[2]) - $(ac.equation.args[3]) ))
         
         ex6a = :(
             JuMP.@NLexpression(
@@ -13,7 +13,7 @@ function build_auxconstraints!(m::Model, jm)
             )
         )
 
-        ex6b = eval(swap_our_param_with_jump_param(jm, ex6a))
+        ex6b = eval(swap_our_Ref_with_jump_var(jm, ex6a))
         Complementarity.add_complementarity(jm, get_jump_variable_for_aux(jm, ac.aux), ex6b, string("F_", get_name(ac.aux, true)))
         push!(m._nlexpressions, ex6b)
     end

--- a/src/build/build_helpers.jl
+++ b/src/build/build_helpers.jl
@@ -16,7 +16,7 @@ function swap_our_Ref_with_jump_var(jm, expr)
             get_jump_variable_for_sector(jm, x)
         elseif x isa ConsumerRef
             get_jump_variable_for_consumer(jm, x)
-        elseif x isa ImplicitvarRef
+        elseif x isa ImplicitsupRef || x isa ImplicitdemRef || x isa ImplicitfinaldemRef
             get_jump_variable_for_implicitvar(jm, x)
         else
             return x
@@ -129,7 +129,7 @@ function get_jump_variable_for_commodity(jm, commodity::IndexedCommodity)
     return jm[get_name(commodity)][commodity.subindex]
 end
 
-function get_jump_expression_for_commodity_producer_price(m::Model, jm, pf, commodity::CommodityRef)
+function get_expression_for_commodity_producer_price(pf, commodity::CommodityRef)
 
     taxes = []
         for output in pf.outputs
@@ -145,7 +145,7 @@ function get_jump_expression_for_commodity_producer_price(m::Model, jm, pf, comm
     return :($commodity * (1. - $tax))
 end
 
-function get_jump_expression_for_commodity_consumer_price(m::Model, jm, pf, commodity::CommodityRef)
+function get_expression_for_commodity_consumer_price(pf, commodity::CommodityRef)
 
     taxes = []
     for input in pf.inputs
@@ -245,35 +245,29 @@ function get_jump_variable_for_aux(jm, aux::AuxRef)
     end
 end
 
-function get_jump_variable_for_aux(jm, a::ScalarAux)
-    return jm[get_name(a)]
+function get_jump_variable_for_implicitvar(jm, im::ImplicitsupRef)
+    if im.subindex===nothing    
+        return jm[get_name(im)]
+    else
+        return jm[get_name(im)][im.subindex]
+    end
 end
 
-function get_jump_variable_for_aux(jm, a::IndexedAux)
-    return jm[get_name(a)][a.subindex]
+function get_jump_variable_for_implicitvar(jm, im::ImplicitdemRef)
+    if im.subindex===nothing    
+        return jm[get_name(im)]
+    else
+        return jm[get_name(im)][im.subindex]
+    end
 end
 
-function get_jump_variable_for_implicitvar(jm, im::ImplicitvarRef)
-    # if im.type isa Output
-    #     return jm[get_comp_supply_name(im.type)]
-    # elseif im.type isa Input
-    #     return jm[get_comp_demand_name(im.type)]
-    # elseif im.type isa Demand
-        return jm[get_final_demand_name(im.type)]
-    # end
+function get_jump_variable_for_implicitvar(jm, im::ImplicitfinaldemRef)
+    if im.subindex===nothing    
+        return jm[get_name(im)]
+    else
+        return jm[get_name(im)][im.subindex]
+    end
 end
-
-# function get_jump_variable_for_intermediate_supply(jm, output)
-#     return jm[get_comp_supply_name(output)]
-# end
-
-# function get_jump_variable_for_intermediate_demand(jm, input)
-#     return jm[get_comp_demand_name(input)]
-# end
-
-# function get_jump_variable_for_final_demand(jm, demand)
-#     return jm[get_final_demand_name(demand)]
-# end
 
 function get_prod_func_name(x::Production)
     return Symbol("$(get_name(x.sector, true))")

--- a/src/build/build_helpers.jl
+++ b/src/build/build_helpers.jl
@@ -1,17 +1,13 @@
 """
-    swap_our_param_with_jump_param(jm, expr)
+    swap_our_Ref_with_jump_var(jm, expr)
 
 This function takes an expression tree and replaces all instances of
 `ParameterRef` with the corresponding `JuMP.NLParameter`.
 """
-function swap_our_param_with_jump_param(jm, expr)
+function swap_our_Ref_with_jump_var(jm, expr)
     return MacroTools.postwalk(expr) do x
         if x isa ParameterRef
-            if x.subindex===nothing
-                return jm[x.model._parameters[x.index].name]
-            else
-                return jm[x.model._parameters[x.index].name][x.subindex]
-            end
+            get_jump_variable_for_param(jm, x)
         elseif x isa CommodityRef
             get_jump_variable_for_commodity(jm, x)
         elseif x isa AuxRef
@@ -71,7 +67,7 @@ end
 contains_our_param(expr)
 
 This function takes an expression tree and tests whether it contains
-a `ParameterRef`` or `CommodityRef`
+a `ParameterRef` or `CommodityRef`
 """
 function contains_our_param(expr)
     if expr isa Expr
@@ -89,11 +85,20 @@ function contains_our_param(expr)
     end
 end
 
+
 function get_jump_variable_for_sector(jm, sector)
     if sector.subindex===nothing
         return jm[get_name(sector)]
     else
         return jm[get_name(sector)][sector.subindex]
+    end
+end
+
+function get_jump_variable_for_param(jm, parameter::ParameterRef)
+    if parameter.subindex===nothing
+        return jm[parameter.model._parameters[parameter.index].name]
+    else
+        return jm[parameter.model._parameters[parameter.index].name][parameter.subindex]
     end
 end
 
@@ -123,7 +128,6 @@ function get_jump_variable_for_commodity(jm, commodity::IndexedCommodity)
 end
 
 function get_jump_expression_for_commodity_producer_price(m::Model, jm, pf, commodity::CommodityRef)
-    jump_commodity = get_jump_variable_for_commodity(jm, commodity)
 
     taxes = []
         for output in pf.outputs
@@ -136,11 +140,11 @@ function get_jump_expression_for_commodity_producer_price(m::Model, jm, pf, comm
 
     tax = :(+(0., $(taxes...)))
 
-    return :($jump_commodity * (1. - $tax))
+    return :($commodity * (1. - $tax))
 end
 
 function get_jump_expression_for_commodity_consumer_price(m::Model, jm, pf, commodity::CommodityRef)
-    jump_commodity = get_jump_variable_for_commodity(jm, commodity)
+
     taxes = []
     for input in pf.inputs
         if input.commodity == commodity
@@ -152,7 +156,7 @@ function get_jump_expression_for_commodity_consumer_price(m::Model, jm, pf, comm
 
     tax = :(+(0., $(taxes...)))
 
-    return :($jump_commodity * (1. + $tax))
+    return :($commodity * (1. + $tax))
 end
 
 function get_jump_variable_for_consumer(jm, consumer::ConsumerRef)
@@ -247,17 +251,17 @@ function get_jump_variable_for_aux(jm, a::IndexedAux)
     return jm[get_name(a)][a.subindex]
 end
 
-function get_jump_variable_for_intermediate_supply(jm, output)
-    return jm[get_comp_supply_name(output)]
-end
+# function get_jump_variable_for_intermediate_supply(jm, output)
+#     return jm[get_comp_supply_name(output)]
+# end
 
-function get_jump_variable_for_intermediate_demand(jm, input)
-    return jm[get_comp_demand_name(input)]
-end
+# function get_jump_variable_for_intermediate_demand(jm, input)
+#     return jm[get_comp_demand_name(input)]
+# end
 
-function get_jump_variable_for_final_demand(jm, demand)
-    return jm[get_final_demand_name(demand)]
-end
+# function get_jump_variable_for_final_demand(jm, demand)
+#     return jm[get_final_demand_name(demand)]
+# end
 
 function get_prod_func_name(x::Production)
     return Symbol("$(get_name(x.sector, true))")
@@ -265,11 +269,6 @@ end
 
 function get_demand_func_name(x::DemandFunction)
     return Symbol("$(get_name(x.consumer, true))")
-end
-
-function get_comp_demand_name(i::Input)
-    p = i.production_function::Production 
-    return Symbol("$(get_name(i.commodity, true))†$(get_prod_func_name(p))")
 end
 
 function get_comp_supply_name(o::Output)
@@ -280,4 +279,9 @@ end
 function get_final_demand_name(demand::Demand)
     demand_function = demand.demand_function::DemandFunction
     return Symbol("$(get_name(demand.commodity, true))ρ$(get_demand_func_name(demand_function))")
+end
+
+function get_comp_demand_name(i::Input)
+    p = i.production_function::Production 
+    return Symbol("$(get_name(i.commodity, true))†$(get_prod_func_name(p))")
 end

--- a/src/build/build_helpers.jl
+++ b/src/build/build_helpers.jl
@@ -16,6 +16,8 @@ function swap_our_Ref_with_jump_var(jm, expr)
             get_jump_variable_for_sector(jm, x)
         elseif x isa ConsumerRef
             get_jump_variable_for_consumer(jm, x)
+        elseif x isa ImplicitvarRef
+            get_jump_variable_for_implicitvar(jm, x)
         else
             return x
         end
@@ -249,6 +251,16 @@ end
 
 function get_jump_variable_for_aux(jm, a::IndexedAux)
     return jm[get_name(a)][a.subindex]
+end
+
+function get_jump_variable_for_implicitvar(jm, im::Implicitvar)
+    if im.type isa Output
+        return jm[get_comp_supply_name(im.type)]
+    elseif im.type isa Input
+        return jm[get_comp_demand_name(im.type)]
+    elseif im.type isa Demand
+        return jm[get_final_demand_name(im.type)]
+    end
 end
 
 # function get_jump_variable_for_intermediate_supply(jm, output)

--- a/src/build/build_helpers.jl
+++ b/src/build/build_helpers.jl
@@ -253,14 +253,14 @@ function get_jump_variable_for_aux(jm, a::IndexedAux)
     return jm[get_name(a)][a.subindex]
 end
 
-function get_jump_variable_for_implicitvar(jm, im::Implicitvar)
-    if im.type isa Output
-        return jm[get_comp_supply_name(im.type)]
-    elseif im.type isa Input
-        return jm[get_comp_demand_name(im.type)]
-    elseif im.type isa Demand
+function get_jump_variable_for_implicitvar(jm, im::ImplicitvarRef)
+    # if im.type isa Output
+    #     return jm[get_comp_supply_name(im.type)]
+    # elseif im.type isa Input
+    #     return jm[get_comp_demand_name(im.type)]
+    # elseif im.type isa Demand
         return jm[get_final_demand_name(im.type)]
-    end
+    # end
 end
 
 # function get_jump_variable_for_intermediate_supply(jm, output)

--- a/src/build/build_helpers.jl
+++ b/src/build/build_helpers.jl
@@ -16,7 +16,8 @@ function swap_our_Ref_with_jump_var(jm, expr)
             get_jump_variable_for_sector(jm, x)
         elseif x isa ConsumerRef
             get_jump_variable_for_consumer(jm, x)
-        elseif x isa ImplicitsupRef || x isa ImplicitdemRef || x isa ImplicitfinaldemRef
+        elseif x isa ImplicitvarRef
+        # elseif x isa ImplicitsupRef || x isa ImplicitdemRef || x isa ImplicitfinaldemRef
             get_jump_variable_for_implicitvar(jm, x)
         else
             return x
@@ -245,7 +246,7 @@ function get_jump_variable_for_aux(jm, aux::AuxRef)
     end
 end
 
-function get_jump_variable_for_implicitvar(jm, im::ImplicitsupRef)
+function get_jump_variable_for_implicitvar(jm, im::ImplicitvarRef)
     # if im.subindex===nothing    
         return jm[get_name(im)]
     # else
@@ -253,21 +254,21 @@ function get_jump_variable_for_implicitvar(jm, im::ImplicitsupRef)
     # end
 end
 
-function get_jump_variable_for_implicitvar(jm, im::ImplicitdemRef)
-    # if im.subindex===nothing    
-        return jm[get_name(im)]
-    # else
-        # return jm[get_name(im)][im.subindex]
-    # end
-end
+# function get_jump_variable_for_implicitvar(jm, im::ImplicitdemRef)
+#     # if im.subindex===nothing    
+#         return jm[get_name(im)]
+#     # else
+#         # return jm[get_name(im)][im.subindex]
+#     # end
+# end
 
-function get_jump_variable_for_implicitvar(jm, im::ImplicitfinaldemRef)
-    # if im.subindex===nothing    
-        return jm[get_name(im)]
-    # else
-        # return jm[get_name(im)][im.subindex]
-    # end
-end
+# function get_jump_variable_for_implicitvar(jm, im::ImplicitfinaldemRef)
+#     # if im.subindex===nothing    
+#         return jm[get_name(im)]
+#     # else
+#         # return jm[get_name(im)][im.subindex]
+#     # end
+# end
 
 function get_prod_func_name(x::Production)
     return Symbol("$(get_name(x.sector, true))")

--- a/src/build/build_helpers.jl
+++ b/src/build/build_helpers.jl
@@ -17,7 +17,6 @@ function swap_our_Ref_with_jump_var(jm, expr)
         elseif x isa ConsumerRef
             get_jump_variable_for_consumer(jm, x)
         elseif x isa ImplicitvarRef
-        # elseif x isa ImplicitsupRef || x isa ImplicitdemRef || x isa ImplicitfinaldemRef
             get_jump_variable_for_implicitvar(jm, x)
         else
             return x
@@ -253,22 +252,6 @@ function get_jump_variable_for_implicitvar(jm, im::ImplicitvarRef)
         # return jm[get_name(im)][im.subindex]
     # end
 end
-
-# function get_jump_variable_for_implicitvar(jm, im::ImplicitdemRef)
-#     # if im.subindex===nothing    
-#         return jm[get_name(im)]
-#     # else
-#         # return jm[get_name(im)][im.subindex]
-#     # end
-# end
-
-# function get_jump_variable_for_implicitvar(jm, im::ImplicitfinaldemRef)
-#     # if im.subindex===nothing    
-#         return jm[get_name(im)]
-#     # else
-#         # return jm[get_name(im)][im.subindex]
-#     # end
-# end
 
 function get_prod_func_name(x::Production)
     return Symbol("$(get_name(x.sector, true))")

--- a/src/build/build_helpers.jl
+++ b/src/build/build_helpers.jl
@@ -246,27 +246,27 @@ function get_jump_variable_for_aux(jm, aux::AuxRef)
 end
 
 function get_jump_variable_for_implicitvar(jm, im::ImplicitsupRef)
-    if im.subindex===nothing    
+    # if im.subindex===nothing    
         return jm[get_name(im)]
-    else
-        return jm[get_name(im)][im.subindex]
-    end
+    # else
+        # return jm[get_name(im)][im.subindex]
+    # end
 end
 
 function get_jump_variable_for_implicitvar(jm, im::ImplicitdemRef)
-    if im.subindex===nothing    
+    # if im.subindex===nothing    
         return jm[get_name(im)]
-    else
-        return jm[get_name(im)][im.subindex]
-    end
+    # else
+        # return jm[get_name(im)][im.subindex]
+    # end
 end
 
 function get_jump_variable_for_implicitvar(jm, im::ImplicitfinaldemRef)
-    if im.subindex===nothing    
+    # if im.subindex===nothing    
         return jm[get_name(im)]
-    else
-        return jm[get_name(im)][im.subindex]
-    end
+    # else
+        # return jm[get_name(im)][im.subindex]
+    # end
 end
 
 function get_prod_func_name(x::Production)

--- a/src/build/build_implicitconstraints.jl
+++ b/src/build/build_implicitconstraints.jl
@@ -134,7 +134,7 @@ function create_expenditure_expr(jm, df::DemandFunction)
                         :(
                             $(Θ(df, dm)) *
                             (
-                                $(get_jump_variable_for_commodity(jm, dm.commodity)) /
+                                $(dm.commodity) /
                                 ($(get_commodity_benchmark(dm.commodity)) * $(dm.price))
                             )^(1-$(df.elasticity))
                         ) for dm in df.demands
@@ -164,7 +164,7 @@ function build_implicitconstraints!(m, jm)
                 )
             )
 
-            exb = eval( swap_our_param_with_jump_param(jm, ex) )
+            exb = eval( swap_our_Ref_with_jump_var(jm, ex) )
 
             Complementarity.add_complementarity(jm, jm[get_comp_demand_name(input)], exb, string("F_", get_comp_demand_name(input)))    
             push!(m._nlexpressions, exb)
@@ -188,7 +188,7 @@ function build_implicitconstraints!(m, jm)
                 )
             )
 
-            exb = eval( swap_our_param_with_jump_param(jm, ex) )
+            exb = eval( swap_our_Ref_with_jump_var(jm, ex) )
 
             Complementarity.add_complementarity(jm, jm[get_comp_supply_name(output)], exb, string("F_", get_comp_supply_name(output)))
             push!(m._nlexpressions, exb)
@@ -203,7 +203,7 @@ function build_implicitconstraints!(m, jm)
                         $(jm),
                         $(demand.quantity) * 
                         (
-                            $(get_jump_variable_for_consumer(jm, demand_function.consumer)) / # (consumer's) income
+                            $(demand_function.consumer) / # (consumer's) income
                             (+($( (:( $(d.quantity) * $(d.price) * $(get_commodity_benchmark(d.commodity)) ) for d in demand_function.demands)...) )) # benchmark income (?)
                         ) *
                         (
@@ -211,12 +211,12 @@ function build_implicitconstraints!(m, jm)
                         )^($(demand_function.elasticity)-1) *
                         (
                             $(get_commodity_benchmark(demand.commodity)) * $(demand.price) / # p__bar_i
-                            $(get_jump_variable_for_commodity(jm, demand.commodity))
+                            $(demand.commodity)
                         )^$(demand_function.elasticity) - # p_i
                         $(jm[get_final_demand_name(demand)])
                     )
                 )
-                exb = eval( swap_our_param_with_jump_param(jm, ex) )
+                exb = eval( swap_our_Ref_with_jump_var(jm, ex) )
 
                 Complementarity.add_complementarity(jm, jm[get_final_demand_name(demand)], exb, string("F_", get_final_demand_name(demand)))
                 push!(m._nlexpressions, exb)

--- a/src/build/build_incomebalance.jl
+++ b/src/build/build_incomebalance.jl
@@ -4,15 +4,15 @@ function build_incomebalance!(m, jm)
         ex6a = :(
             JuMP.@NLexpression(
                 $jm,
-                +($((:($(swap_our_param_with_jump_param(jm, en.quantity)) * 
-                $(get_jump_variable_for_commodity(jm, en.commodity))) for en in c.endowments)...)) 
+                +($((:($(en.quantity) * 
+                $(en.commodity)) for en in c.endowments)...)) 
                 +  $(get_tax_revenue_for_consumer(jm, m, c.consumer)) 
                 -
-                $(get_jump_variable_for_consumer(jm, c.consumer))
+                $(c.consumer)
             )
         )
 
-        ex6b = eval(swap_our_param_with_jump_param(jm, ex6a))
+        ex6b = eval(swap_our_Ref_with_jump_var(jm, ex6a))
         Complementarity.add_complementarity(jm, get_jump_variable_for_consumer(jm, c.consumer), ex6b, string("F_", get_name(c.consumer, true)))
         push!(m._nlexpressions, ex6b)
     end

--- a/src/build/build_marketclearance.jl
+++ b/src/build/build_marketclearance.jl
@@ -45,7 +45,8 @@ function build_marketclearance!(m, jm)
         for demand_function in m._demands
             for demand in demand_function.demands
                 if demand.commodity == commodity
-                    push!(final_demand, :($(jm[get_final_demand_name(demand)])))#$(get_jump_variable_for_final_demand(jm, demand))))
+                    # push!(final_demand, :($(m._implicitvarsDict[get_final_demand_name(demand)])))
+                    push!(final_demand, :($(jm[get_final_demand_name(demand)])))
                 end
             end
         end

--- a/src/build/build_marketclearance.jl
+++ b/src/build/build_marketclearance.jl
@@ -35,7 +35,7 @@ function build_marketclearance!(m, jm)
         for production_function in m._productions
             for output in production_function.outputs
                 if output.commodity==commodity
-                    push!(comp_supplies, :($(get_jump_variable_for_sector(jm, production_function.sector)) * $(get_jump_variable_for_intermediate_supply(jm, output))))
+                    push!(comp_supplies, :($(production_function.sector) * $(jm[get_comp_supply_name(output)])))#$(jm[get_comp_supply_name(output)])))#$(get_jump_variable_for_intermediate_supply(jm, output))))
                 end
             end
         end
@@ -45,7 +45,7 @@ function build_marketclearance!(m, jm)
         for demand_function in m._demands
             for demand in demand_function.demands
                 if demand.commodity == commodity
-                    push!(final_demand, :($(get_jump_variable_for_final_demand(jm, demand))))
+                    push!(final_demand, :($(jm[get_final_demand_name(demand)])))#$(get_jump_variable_for_final_demand(jm, demand))))
                 end
             end
         end
@@ -55,7 +55,7 @@ function build_marketclearance!(m, jm)
         for production_function in m._productions
             for input in production_function.inputs
                 if input.commodity==commodity
-                    push!(comp_demands, :($(get_jump_variable_for_sector(jm, production_function.sector)) * $(get_jump_variable_for_intermediate_demand(jm, input))))
+                    push!(comp_demands, :($(production_function.sector) * $(jm[get_comp_demand_name(input)])))#$(get_jump_variable_for_intermediate_demand(jm, input))))
                 end
             end
         end
@@ -66,7 +66,7 @@ function build_marketclearance!(m, jm)
                 +(0., $(endows...), $(comp_supplies...)) - +(0., $(final_demand...), $(comp_demands...))
             )
         )
-        exb = eval(swap_our_param_with_jump_param(jm, exa))
+        exb = eval(swap_our_Ref_with_jump_var(jm, exa))
 
         Complementarity.add_complementarity(jm, get_jump_variable_for_commodity(jm, commodity), exb, string("F_", get_name(commodity, true)))
         push!(m._nlexpressions, exb)

--- a/src/build/build_marketclearance.jl
+++ b/src/build/build_marketclearance.jl
@@ -35,7 +35,7 @@ function build_marketclearance!(m, jm)
         for production_function in m._productions
             for output in production_function.outputs
                 if output.commodity==commodity
-                    push!(comp_supplies, :($(production_function.sector) * $(jm[get_comp_supply_name(output)])))#$(jm[get_comp_supply_name(output)])))#$(get_jump_variable_for_intermediate_supply(jm, output))))
+                    push!(comp_supplies, :($(production_function.sector) * $(m._implicitvarsDict[get_comp_supply_name(output)])))
                 end
             end
         end
@@ -45,8 +45,7 @@ function build_marketclearance!(m, jm)
         for demand_function in m._demands
             for demand in demand_function.demands
                 if demand.commodity == commodity
-                    # push!(final_demand, :($(m._implicitvarsDict[get_final_demand_name(demand)])))
-                    push!(final_demand, :($(jm[get_final_demand_name(demand)])))
+                    push!(final_demand, :($(m._implicitvarsDict[get_final_demand_name(demand)])))
                 end
             end
         end
@@ -56,7 +55,7 @@ function build_marketclearance!(m, jm)
         for production_function in m._productions
             for input in production_function.inputs
                 if input.commodity==commodity
-                    push!(comp_demands, :($(production_function.sector) * $(jm[get_comp_demand_name(input)])))#$(get_jump_variable_for_intermediate_demand(jm, input))))
+                    push!(comp_demands, :($(production_function.sector) * $(m._implicitvarsDict[get_comp_demand_name(input)])))
                 end
             end
         end

--- a/src/build/build_variables.jl
+++ b/src/build/build_variables.jl
@@ -49,6 +49,29 @@ function add_aux_to_jump!(jm, aux::IndexedAux)
     jm[aux.name] = @eval(JuMP.@variable($jm, [$( ( :($(gensym())=$i) for i in aux.indices)... )], base_name=string($(QuoteNode(aux.name))), lower_bound=0.))
 end
 
+function add_implicitvars!(m)
+    # Add compensated supply variable Refs to model
+    for s in m._productions
+        for o in s.outputs
+            # global m
+            # global get_comp_supply_name(o) = add!(m, (Implicitvar(get_comp_supply_name(o), typeof(o))))
+            addimp = :($(get_comp_supply_name(o)) = add!($m, (Implicitvar(get_comp_supply_name($o), typeof($o)))))
+             return eval(addimp)
+        end
+    end
+    # Add compensated demand variables
+    for s in m._productions
+        for i in s.inputs
+            add!(m, Implicitvar(get_comp_demand_name(i), typeof(i)))
+        end
+    end
+   # Add final demand variables
+   for demand_function in m._demands
+        for demand in demand_function.demands
+            add!(m, Implicitvar(get_final_demand_name(demand), typeof(demand)))
+        end
+    end
+end
 
 function build_variables!(m, jm)
     # Add all parameters

--- a/src/build/build_variables.jl
+++ b/src/build/build_variables.jl
@@ -54,10 +54,6 @@ function add_implicitvars!(m)
     for s in m._productions
         for o in s.outputs
             add!(m, Implicitvar(get_comp_supply_name(o), typeof(o)))
-            # global m
-            # global get_comp_supply_name(o) = add!(m, (Implicitvar(get_comp_supply_name(o), typeof(o))))
-            # addimp = :($(get_comp_supply_name(o)) = add!($m, (Implicitvar(get_comp_supply_name($o), typeof($o)))))
-            #  return eval(addimp)
         end
     end
     # Add compensated demand variables

--- a/src/build/build_variables.jl
+++ b/src/build/build_variables.jl
@@ -53,10 +53,11 @@ function add_implicitvars!(m)
     # Add compensated supply variable Refs to model
     for s in m._productions
         for o in s.outputs
+            add!(m, Implicitvar(get_comp_supply_name(o), typeof(o)))
             # global m
             # global get_comp_supply_name(o) = add!(m, (Implicitvar(get_comp_supply_name(o), typeof(o))))
-            addimp = :($(get_comp_supply_name(o)) = add!($m, (Implicitvar(get_comp_supply_name($o), typeof($o)))))
-             return eval(addimp)
+            # addimp = :($(get_comp_supply_name(o)) = add!($m, (Implicitvar(get_comp_supply_name($o), typeof($o)))))
+            #  return eval(addimp)
         end
     end
     # Add compensated demand variables

--- a/src/build/build_zeroprofit.jl
+++ b/src/build/build_zeroprofit.jl
@@ -8,14 +8,14 @@ function build_zeroprofit!(m, jm)
                 +(
                     $(
                         (:(
-                            $(get_jump_expression_for_commodity_consumer_price(m, jm, s, input.commodity)) * $(jm[get_comp_demand_name(input)]) 
+                            $(get_expression_for_commodity_consumer_price(s, input.commodity)) * $(m._implicitvarsDict[get_comp_demand_name(input)]) 
                         ) for input in s.inputs)...
                 )
                 ) -
                 +(
                     $(
                         (:(
-                            $(get_jump_expression_for_commodity_producer_price(m, jm, s, output.commodity)) * $(jm[get_comp_supply_name(output)])
+                            $(get_expression_for_commodity_producer_price(s, output.commodity)) * $(m._implicitvarsDict[get_comp_supply_name(output)])
                         ) for output in s.outputs)...
                     )
                 )

--- a/src/build/build_zeroprofit.jl
+++ b/src/build/build_zeroprofit.jl
@@ -22,7 +22,7 @@ function build_zeroprofit!(m, jm)
             )
         )
 
-        exb = eval(swap_our_param_with_jump_param(jm, exa))
+        exb = eval(swap_our_Ref_with_jump_var(jm, exa))
 
         Complementarity.add_complementarity(jm, get_jump_variable_for_sector(jm, s.sector), exb, string("F_", get_name(s.sector), s.sector.subindex!==nothing ? s.sector.subindex : ""))
         push!(m._nlexpressions, exb)

--- a/src/model.jl
+++ b/src/model.jl
@@ -33,6 +33,13 @@ struct AuxRef
     subindex_names::Any
 end
 
+struct ImplicitvarRef
+    model
+    index::Int
+    subindex::Any
+    subindex_names::Any
+end
+
 """
     Parameter(:symbol; indices, value::Float64=1., string)
     Struct that holds the name, indices if IndexedParameter, value, and optional description of a parameter within the model.
@@ -301,6 +308,11 @@ struct Endowment
     quantity::Union{Float64,Expr}
 end
 
+struct Implicitvar
+    name::Symbol
+    type::Any
+end
+
 mutable struct Demand
     commodity::Any
     quantity::Union{Float64,Expr}
@@ -349,6 +361,7 @@ mutable struct Model
     _commodities::Vector{Commodity}
     _consumers::Vector{Consumer}
     _auxs::Vector{Aux}
+    _implicitvars::Vector{Implicitvar}
 
     _productions::Vector{Production}
     _demands::Vector{DemandFunction}
@@ -366,6 +379,7 @@ mutable struct Model
             Commodity[],
             Consumer[],
             Aux[],
+            Implicitvar[],
             Production[],
             DemandFunction[],
             AuxConstraint[],
@@ -726,6 +740,13 @@ function add!(m::Model, p::IndexedParameter)
     end
     return JuMP.Containers.DenseAxisArray(temp_array, p.indices...)
 end
+
+function add!(m::Model, im::Implicitvar)
+    m._jump_model = nothing
+    push!(m._implicitvars, im)
+    return ImplicitvarRef(m, length(m._implicitvars), nothing, nothing)
+end
+
 
 function JuMP.value(m::Model, name::Symbol)
     Complementarity.result_value(m._jump_model[name])

--- a/src/model.jl
+++ b/src/model.jl
@@ -33,26 +33,32 @@ struct AuxRef
     subindex_names::Any
 end
 
-struct ImplicitsupRef
+struct ImplicitvarRef
     model
     index::Int
     subindex::Any
     subindex_names::Any
 end
+# struct ImplicitsupRef
+#     model
+#     index::Int
+#     subindex::Any
+#     subindex_names::Any
+# end
 
-struct ImplicitdemRef
-    model
-    index::Int
-    subindex::Any
-    subindex_names::Any
-end
+# struct ImplicitdemRef
+#     model
+#     index::Int
+#     subindex::Any
+#     subindex_names::Any
+# end
 
-struct ImplicitfinaldemRef
-    model
-    index::Int
-    subindex::Any
-    subindex_names::Any
-end
+# struct ImplicitfinaldemRef
+#     model
+#     index::Int
+#     subindex::Any
+#     subindex_names::Any
+# end
 
 """
     Parameter(:symbol; indices, value::Float64=1., string)
@@ -376,7 +382,7 @@ mutable struct Model
     _consumers::Vector{Consumer}
     _auxs::Vector{Aux}
     _implicitvars::Vector{Implicitvar}
-    _implicitvarsDict::Dict{Symbol, Union{ImplicitsupRef, ImplicitdemRef, ImplicitfinaldemRef}}
+    _implicitvarsDict::Dict{Symbol, ImplicitvarRef}#Union{ImplicitsupRef, ImplicitdemRef, ImplicitfinaldemRef}}
 
     _productions::Vector{Production}
     _demands::Vector{DemandFunction}
@@ -395,7 +401,7 @@ mutable struct Model
             Consumer[],
             Aux[],
             Implicitvar[],
-            Dict{Symbol, Union{ImplicitsupRef, ImplicitdemRef, ImplicitfinaldemRef}}(),
+            Dict{Symbol, ImplicitvarRef}(),#Union{ImplicitsupRef, ImplicitdemRef, ImplicitfinaldemRef}}(),
 
             Production[],
             DemandFunction[],
@@ -480,23 +486,23 @@ function get_name(aux::AuxRef, include_subindex=false)
     end 
 end
 
-function get_name(im::ImplicitdemRef, include_subindex=false)
+# function get_name(im::ImplicitdemRef, include_subindex=false)
     # if im.subindex===nothing || include_subindex===false
-        return im.model._implicitvars[im.index].name
+        # return im.model._implicitvars[im.index].name
     # else
         # return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
     # end 
-end
+# end
 
-function get_name(im::ImplicitsupRef, include_subindex=false)
+# function get_name(im::ImplicitsupRef, include_subindex=false)
     # if im.subindex===nothing || include_subindex===false
-        return im.model._implicitvars[im.index].name
+        # return im.model._implicitvars[im.index].name
     # else
         # return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
     # end 
-end
+# end
 
-function get_name(im::ImplicitfinaldemRef, include_subindex=false)
+function get_name(im::ImplicitvarRef, include_subindex=false)
     # if im.subindex===nothing || include_subindex===false
         return im.model._implicitvars[im.index].name
     # else
@@ -767,13 +773,13 @@ end
 function add!(m::Model, im::Implicitvar)
     m._jump_model = nothing
     push!(m._implicitvars, im)
-    if im.type isa Output
-        push!(m._implicitvarsDict,im.name=>ImplicitsupRef(m, length(m._implicitvars), nothing, nothing))
-    elseif im.type isa Input
-        push!(m._implicitvarsDict,im.name=>ImplicitdemRef(m, length(m._implicitvars), nothing, nothing))
-    else
-        push!(m._implicitvarsDict,im.name=>ImplicitfinaldemRef(m, length(m._implicitvars), nothing, nothing))
-    end
+    # if im.type isa Output
+    #     push!(m._implicitvarsDict,im.name=>ImplicitsupRef(m, length(m._implicitvars), nothing, nothing))
+    # elseif im.type isa Input
+    #     push!(m._implicitvarsDict,im.name=>ImplicitdemRef(m, length(m._implicitvars), nothing, nothing))
+    # else
+        push!(m._implicitvarsDict,im.name=>ImplicitvarRef(m, length(m._implicitvars), nothing, nothing))
+    # end
 end
 
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -39,26 +39,6 @@ struct ImplicitvarRef
     subindex::Any
     subindex_names::Any
 end
-# struct ImplicitsupRef
-#     model
-#     index::Int
-#     subindex::Any
-#     subindex_names::Any
-# end
-
-# struct ImplicitdemRef
-#     model
-#     index::Int
-#     subindex::Any
-#     subindex_names::Any
-# end
-
-# struct ImplicitfinaldemRef
-#     model
-#     index::Int
-#     subindex::Any
-#     subindex_names::Any
-# end
 
 """
     Parameter(:symbol; indices, value::Float64=1., string)
@@ -382,7 +362,7 @@ mutable struct Model
     _consumers::Vector{Consumer}
     _auxs::Vector{Aux}
     _implicitvars::Vector{Implicitvar}
-    _implicitvarsDict::Dict{Symbol, ImplicitvarRef}#Union{ImplicitsupRef, ImplicitdemRef, ImplicitfinaldemRef}}
+    _implicitvarsDict::Dict{Symbol, ImplicitvarRef}
 
     _productions::Vector{Production}
     _demands::Vector{DemandFunction}
@@ -401,7 +381,7 @@ mutable struct Model
             Consumer[],
             Aux[],
             Implicitvar[],
-            Dict{Symbol, ImplicitvarRef}(),#Union{ImplicitsupRef, ImplicitdemRef, ImplicitfinaldemRef}}(),
+            Dict{Symbol, ImplicitvarRef}(),
 
             Production[],
             DemandFunction[],
@@ -485,14 +465,6 @@ function get_name(aux::AuxRef, include_subindex=false)
         return Symbol("$(aux.model._auxs[aux.index].name )[$(join(string.(aux.subindex_names), ", "))]") 
     end 
 end
-
-# function get_name(im::ImplicitdemRef, include_subindex=false)
-    # if im.subindex===nothing || include_subindex===false
-        # return im.model._implicitvars[im.index].name
-    # else
-        # return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
-    # end 
-# end
 
 function get_name(im::ImplicitvarRef, include_subindex=false)
     # if im.subindex===nothing || include_subindex===false
@@ -765,13 +737,7 @@ end
 function add!(m::Model, im::Implicitvar)
     m._jump_model = nothing
     push!(m._implicitvars, im)
-    # if im.type isa Output
-    #     push!(m._implicitvarsDict,im.name=>ImplicitsupRef(m, length(m._implicitvars), nothing, nothing))
-    # elseif im.type isa Input
-    #     push!(m._implicitvarsDict,im.name=>ImplicitdemRef(m, length(m._implicitvars), nothing, nothing))
-    # else
-        push!(m._implicitvarsDict,im.name=>ImplicitvarRef(m, length(m._implicitvars), nothing, nothing))
-    # end
+    push!(m._implicitvarsDict,im.name=>ImplicitvarRef(m, length(m._implicitvars), nothing, nothing))
 end
 
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -481,27 +481,27 @@ function get_name(aux::AuxRef, include_subindex=false)
 end
 
 function get_name(im::ImplicitdemRef, include_subindex=false)
-    if im.subindex===nothing || include_subindex===false
+    # if im.subindex===nothing || include_subindex===false
         return im.model._implicitvars[im.index].name
-    else
-        return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
-    end 
+    # else
+        # return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
+    # end 
 end
 
 function get_name(im::ImplicitsupRef, include_subindex=false)
-    if im.subindex===nothing || include_subindex===false
+    # if im.subindex===nothing || include_subindex===false
         return im.model._implicitvars[im.index].name
-    else
-        return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
-    end 
+    # else
+        # return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
+    # end 
 end
 
 function get_name(im::ImplicitfinaldemRef, include_subindex=false)
-    if im.subindex===nothing || include_subindex===false
+    # if im.subindex===nothing || include_subindex===false
         return im.model._implicitvars[im.index].name
-    else
-        return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
-    end 
+    # else
+    #     return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
+    # end 
 end
 
 function get_full(s::SectorRef)

--- a/src/model.jl
+++ b/src/model.jl
@@ -38,6 +38,7 @@ struct ImplicitvarRef
     index::Int
     subindex::Any
     subindex_names::Any
+    # type::Any
 end
 
 """
@@ -362,6 +363,7 @@ mutable struct Model
     _consumers::Vector{Consumer}
     _auxs::Vector{Aux}
     _implicitvars::Vector{Implicitvar}
+    _implicitvarsDict::Dict{Symbol, ImplicitvarRef}
 
     _productions::Vector{Production}
     _demands::Vector{DemandFunction}
@@ -380,6 +382,8 @@ mutable struct Model
             Consumer[],
             Aux[],
             Implicitvar[],
+            Dict{Symbol, ImplicitvarRef}(),
+
             Production[],
             DemandFunction[],
             AuxConstraint[],
@@ -744,7 +748,8 @@ end
 function add!(m::Model, im::Implicitvar)
     m._jump_model = nothing
     push!(m._implicitvars, im)
-    return ImplicitvarRef(m, length(m._implicitvars), nothing, nothing)
+    push!(m._implicitvarsDict,im.name=>ImplicitvarRef(m, length(m._implicitvars), nothing, nothing))
+    # return ImplicitvarRef(m, length(m._implicitvars), nothing, nothing)
 end
 
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -494,14 +494,6 @@ end
     # end 
 # end
 
-# function get_name(im::ImplicitsupRef, include_subindex=false)
-    # if im.subindex===nothing || include_subindex===false
-        # return im.model._implicitvars[im.index].name
-    # else
-        # return Symbol("$(im.model._implicitvars[im.index].name )[$(join(string.(im.subindex_names), ", "))]") 
-    # end 
-# end
-
 function get_name(im::ImplicitvarRef, include_subindex=false)
     # if im.subindex===nothing || include_subindex===false
         return im.model._implicitvars[im.index].name


### PR DESCRIPTION
Where we were calling a JuMP variable in the expression construction, we are replacing those with the Refs, such that the expression is only constructed with JuMP variables as it is passed into JuMP.