### PR TITLE
add separate show for Parameters

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -834,6 +834,16 @@ function JuMP.set_value(consumer::ConsumerRef, new_value::Float64)
     return nothing
 end
 
+function JuMP.set_value(sector::SectorRef, new_value::Float64)
+    s = sector.model._sectors[sector.index]
+    if s isa ScalarSector
+        s.benchmark = new_value
+    else
+        s.benchmark[sector.subindex] = new_value
+    end
+    return nothing
+end
+
 function JuMP.set_value(aux::AuxRef, new_value::Float64)
     a = aux.model._auxs[aux.index]
     if a isa ScalarAux

--- a/src/show.jl
+++ b/src/show.jl
@@ -42,7 +42,7 @@ end
 
 
 
-function Base.show(io::IO,S::Union{SectorRef,CommodityRef,ConsumerRef,AuxRef,ParameterRef})
+function Base.show(io::IO,S::Union{SectorRef,CommodityRef,ConsumerRef,AuxRef})
     #print(io,get_full(S))
     if isnothing(S.subindex)
         return print(io,get_full(S))
@@ -50,6 +50,18 @@ function Base.show(io::IO,S::Union{SectorRef,CommodityRef,ConsumerRef,AuxRef,Par
         names = S.subindex_names
         full_S = get_full(S)
         return print(io,"$(names)\tbm: $(full_S.benchmark[names...])")
+    end
+
+end
+
+function Base.show(io::IO,S::Union{ParameterRef})
+    #print(io,get_full(S))
+    if isnothing(S.subindex)
+        return print(io,get_full(S))
+    else
+        names = S.subindex_names
+        full_S = get_full(S)
+        return print(io,"$(names)\tbm: $(full_S.value[names...])")
     end
 
 end


### PR DESCRIPTION
Added a show method for ParameterRefs because all the other Refs have 'benchmark's, but ParamterRefs have 'value's, which made it break to use parameters in a model solve.