### PR TITLE
fix bug jump name for scalar params

### DIFF
--- a/src/build/build_variables.jl
+++ b/src/build/build_variables.jl
@@ -26,6 +26,7 @@ end
 
 function add_parameter_to_jump!(jm, parameter::ScalarParameter)
     jmp_p = JuMP.@variable(jm, set = JuMP.Parameter(parameter.value))
+    JuMP.set_name(jmp_p, "$(parameter.name)")
     jm[parameter.name] = jmp_p
 end
 


### PR DESCRIPTION
Fix for the bug that scalar parameters weren't getting their names in the jump model, and were coming back as anonymous, with just variable numbers.