### PR TITLE
Updating `prune!` to evaluate parameters before pruning

### DIFF
--- a/src/macros/@production.jl
+++ b/src/macros/@production.jl
@@ -3,7 +3,7 @@
 #####################
 
 function prune!(T::Netput)
-    if quantity(T) != 0 && base_quantity(T) != 0
+    if value(start_value, quantity(T)) != 0 && value(start_value, base_quantity(T)) != 0
         return T
     else
         return nothing
@@ -16,7 +16,7 @@ function prune!(T::AbstractArray{<:Any})
 end
 
 function prune!(T::abstractDemandFlow)
-    if quantity(T) != 0 && base_quantity(T) != 0
+    if value(start_value, quantity(T)) != 0 && value(start_value, base_quantity(T)) != 0
         return T
     else
         return nothing
@@ -25,7 +25,7 @@ end
 
 
 function prune!(T::Node)
-    if quantity(T) == 0
+    if value(start_value, quantity(T)) == 0
         return nothing
     end
     T.children = [e for e∈prune!.(children(T)) if !isnothing(e)]

--- a/test/test_pruning.jl
+++ b/test/test_pruning.jl
@@ -87,3 +87,41 @@ end
     @test !isnothing(P[:b,:a])
     @test !isnothing(P[:b,:b])
 end
+
+
+@testitem "Pruning expressions in quantities" begin
+
+    using MPSGE
+    
+    M = MPSGEModel()
+
+    @parameters(M, begin
+        A, 0
+        B, 1
+    end)
+
+    @sectors(M,begin
+        W
+    end)
+
+    @commodities(M,begin
+        PX
+        PY
+        PW
+    end)
+
+    @production(M, W, [t = 0, s = 1, zero => s = 1], begin
+        @output(PW, 200, t)
+        @input(PX, 100*B, s) # Does not get pruned because B is 1
+        @input(PX, 0/B, zero)
+        @input(PX, 0*B^10, zero)
+        @input(PY, 10*A, zero)
+    end)
+
+
+    P = production(W)
+
+    @test length(get(P.netputs, PX, missing)) == 1
+    @test ismissing(get(P.netputs, PY, missing))
+
+end


### PR DESCRIPTION
# Summary of Changes

- Changed the `prune!` function to check values of quantities rather than the raw expression. This will allow for non-linear expressions in the quantity field to be properly pruned.
- Added a test to ensure this behavior is working properly.

No breaking changes.

Closes #260